### PR TITLE
Add build/debug configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "mii emu",
+			"type": "cppdbg",
+			"preLaunchTask": "${defaultBuildTask}",
+			"request": "launch",
+			"program": "${workspaceFolder}/build-x86_64-redhat-linux/bin/mii_emu",
+			"cwd": "${workspaceFolder}",
+			"args": [
+				"--default",
+				"--drive", "6:1:disks/dos33master.nib",
+			],
+		}
+	],
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Make Build",
+      "type": "shell",
+      "command": "make all",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
You mentioned in https://github.com/buserror/mii_emu/blob/main/docs/Compiling.md#development that vscode lacks Make build options. While true, you can make it run any arbitrary command as a default build task (press ctrl-shift-B). I made an example tasks.json file. It has a link to the docs if you want to see more. I also made a launch.json file to build/start the emulator in the debugger (press F5). Though the platform-triple used by the makefile kinda mucks with that as VSCode requires static paths.